### PR TITLE
Configure Dependabot to only provide security updates for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      "Go modules updates":
+        dependency-type: "production"
+        applies-to: "security-updates"


### PR DESCRIPTION
This change modifies the Dependabot configuration to only provide security updates for Go packages, eliminating regular version updates that can be noisy.