### PR TITLE
Add human-friendly size values with k/m suffixes support

### DIFF
--- a/cmd/mpt/main_integr_test.go
+++ b/cmd/mpt/main_integr_test.go
@@ -719,10 +719,10 @@ func TestHumanSizeValueIntegration(t *testing.T) {
 		if r.URL.Path == "/chat/completions" {
 			// read and parse the request body to check max_tokens value
 			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err, "Failed to read request body")
+			assert.NoError(t, err, "Failed to read request body")
 
 			err = json.Unmarshal(body, &requestData)
-			require.NoError(t, err, "Failed to parse request body")
+			assert.NoError(t, err, "Failed to parse request body")
 
 			// standard OpenAI response
 			resp := `{
@@ -802,7 +802,7 @@ func TestHumanSizeValueIntegration(t *testing.T) {
 	// check that the max_tokens value in the request matched our human-readable setting
 	maxTokens, ok := requestData["max_tokens"]
 	require.True(t, ok, "Request should include max_tokens")
-	require.Equal(t, float64(8192), maxTokens, "max_tokens in API request should be 8192 (8k)")
+	require.InDelta(t, float64(8192), maxTokens.(float64), 0.001, "max_tokens in API request should be 8192 (8k)")
 
 	// verify the response
 	require.Contains(t, output.String(), "Human-size value test response",

--- a/cmd/mpt/main_test.go
+++ b/cmd/mpt/main_test.go
@@ -30,6 +30,90 @@ func TestSetupLog(t *testing.T) {
 	setupLog(true, "secret1", "secret2")
 }
 
+func TestSizeValue_UnmarshalFlag(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  int64
+		shouldErr bool
+	}{
+		{
+			name:     "plain number",
+			input:    "1024",
+			expected: 1024,
+		},
+		{
+			name:     "kilobytes with k",
+			input:    "64k",
+			expected: 65536, // 64 * 1024
+		},
+		{
+			name:     "kilobytes with K",
+			input:    "64K",
+			expected: 65536,
+		},
+		{
+			name:     "kilobytes with kb",
+			input:    "64kb",
+			expected: 65536,
+		},
+		{
+			name:     "kilobytes with KB",
+			input:    "64KB",
+			expected: 65536,
+		},
+		{
+			name:     "megabytes with m",
+			input:    "4m",
+			expected: 4194304, // 4 * 1024 * 1024
+		},
+		{
+			name:     "megabytes with M",
+			input:    "4M",
+			expected: 4194304,
+		},
+		{
+			name:     "megabytes with mb",
+			input:    "4mb",
+			expected: 4194304,
+		},
+		{
+			name:     "megabytes with MB",
+			input:    "4MB",
+			expected: 4194304,
+		},
+		{
+			name:     "value with whitespace",
+			input:    " 128k ",
+			expected: 131072, // 128 * 1024
+		},
+		{
+			name:      "invalid format",
+			input:     "abc",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid suffix",
+			input:     "64x",
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var size SizeValue
+			err := size.UnmarshalFlag(tt.input)
+
+			if tt.shouldErr {
+				assert.Error(t, err, "Expected error for input: %s", tt.input)
+			} else {
+				require.NoError(t, err, "Unexpected error for input: %s", tt.input)
+				assert.Equal(t, SizeValue(tt.expected), size, "Expected %d, got %d for input: %s", tt.expected, size, tt.input)
+			}
+		})
+	}
+}
+
 func TestVerboseOutput(t *testing.T) {
 	// create a buffer to capture output
 	var buf strings.Builder


### PR DESCRIPTION
## Summary
- Added SizeValue type to support human-friendly size specifications (like 64k, 2m) for CLI flags
- Implemented flags.Unmarshaler interface for custom parsing logic
- Applied to MaxFileSize and MaxTokens parameters for all providers
- Added comprehensive unit and integration tests
- Ensures all command line size options support k/m suffixes for better user experience